### PR TITLE
BE - Never Clova OCR API 연동 API 구현

### DIFF
--- a/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/controller/GifticonController.java
+++ b/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/controller/GifticonController.java
@@ -1,18 +1,16 @@
 package com.amatta.amatta_server.gifticon.controller;
 
 import com.amatta.amatta_server.exception.NotAuthenticatedException;
-import com.amatta.amatta_server.gifticon.model.Gifticon;
+import com.amatta.amatta_server.gifticon.dto.GifticonImageDto;
+import com.amatta.amatta_server.gifticon.dto.GifticonTextDto;
 import com.amatta.amatta_server.gifticon.service.GifticonService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@CrossOrigin
 public class GifticonController {
     private final GifticonService gifticonService;
 
@@ -21,10 +19,17 @@ public class GifticonController {
         this.gifticonService = gifticonService;
     }
 
+    @PostMapping("/gift/text")
+    public ResponseEntity<?> gifticonTextExtract(@RequestBody GifticonImageDto dto) {
+        return gifticonService.extractGifticonText(dto);
+    }
+
     @PostMapping("/gift")
-    public ResponseEntity<?> gifticonAdd() {
-        List<Gifticon> gifticonList = gifticonService.findGifticonList();
-        return new ResponseEntity<>(gifticonList, HttpStatus.OK);
+    public ResponseEntity<?> gifticonAdd(@RequestBody GifticonTextDto dto) {
+        System.out.println(dto.getTexts());
+        return null;
+        //List<Gifticon> gifticonList = gifticonService.findGifticonList();
+        //return new ResponseEntity<>(gifticonList, HttpStatus.OK);
     }
 
     @ExceptionHandler(NotAuthenticatedException.class)

--- a/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/dto/GifticonImageDto.java
+++ b/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/dto/GifticonImageDto.java
@@ -1,0 +1,15 @@
+package com.amatta.amatta_server.gifticon.dto;
+
+public class GifticonImageDto {
+    private String gifticonBase64;
+
+    private String format;
+
+    public String getGifticonBase64() {
+        return gifticonBase64;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+}

--- a/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/dto/GifticonTextDto.java
+++ b/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/dto/GifticonTextDto.java
@@ -1,0 +1,11 @@
+package com.amatta.amatta_server.gifticon.dto;
+
+import java.util.List;
+
+public class GifticonTextDto {
+    private List<String> texts;
+
+    public List<String> getTexts() {
+        return texts;
+    }
+}

--- a/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/service/GifticonService.java
+++ b/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/service/GifticonService.java
@@ -1,14 +1,38 @@
 package com.amatta.amatta_server.gifticon.service;
 
 import com.amatta.amatta_server.aop.ClassRequiresAuth;
+import com.amatta.amatta_server.gifticon.dto.GifticonImageDto;
 import com.amatta.amatta_server.gifticon.model.Gifticon;
+import com.amatta.amatta_server.gifticon.util.RequestGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 
 @Service
 @ClassRequiresAuth
 public class GifticonService {
+    private final RequestGenerator requestGenerator;
+
+    @Autowired
+    public GifticonService(RequestGenerator requestGenerator) {
+        this.requestGenerator = requestGenerator;
+    }
+
+    public ResponseEntity<String> extractGifticonText(GifticonImageDto dto) {
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestGenerator.getUrl(),
+                HttpMethod.POST,
+                requestGenerator.generate(dto),
+                String.class
+        );
+        return response;
+    }
+
     public List<Gifticon> findGifticonList() {
         return null;
     }

--- a/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/util/NaverAPIRequestGenerator.java
+++ b/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/util/NaverAPIRequestGenerator.java
@@ -1,0 +1,44 @@
+package com.amatta.amatta_server.gifticon.util;
+
+import com.amatta.amatta_server.gifticon.dto.GifticonImageDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NaverAPIRequestGenerator implements RequestGenerator{
+    @Value("${naver.ocr.gateway}")
+    private String URL;
+
+    @Value("${naver.ocr.x-ocr-secret}")
+    private String X_OCR_SECRET;
+
+    @Override
+    public HttpEntity<String> generate(GifticonImageDto dto) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        headers.set("X-OCR-SECRET", X_OCR_SECRET);
+
+        String requestBody = "{\n" +
+                "  \"version\": \"V2\",\n" +
+                "  \"requestId\": \"string\",\n" +
+                "  \"timestamp\": 0,\n" +
+                "  \"lang\":\"ko\",\n" +
+                "  \"images\": [\n" +
+                "    {\n" +
+                "      \"format\": \"" + dto.getFormat() + "\",\n" +
+                "      \"name\": \"gifticon\",\n" +
+                "      \"data\": \"" + dto.getGifticonBase64() + "\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+
+        HttpEntity<String> request = new HttpEntity<>(requestBody, headers);
+        return request;
+    }
+
+    public String getUrl() {
+        return URL;
+    }
+}

--- a/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/util/RequestGenerator.java
+++ b/amatta_server/src/main/java/com/amatta/amatta_server/gifticon/util/RequestGenerator.java
@@ -1,0 +1,10 @@
+package com.amatta.amatta_server.gifticon.util;
+
+import com.amatta.amatta_server.gifticon.dto.GifticonImageDto;
+import org.springframework.http.HttpEntity;
+
+public interface RequestGenerator {
+    HttpEntity<?> generate(GifticonImageDto dto);
+
+    String getUrl();
+}


### PR DESCRIPTION
1. 프론트에서 전송하는 데이터를 받을 GifticonImageDto 정의
2. RequestGenerator 인터페이스를 이용해 외부 API로 전송할 요청을 생성하는 책임 분리
3. GifticonService에서 외부 API를 호출하고 그 응답을 리턴하는 메소드 추가