### PR TITLE
BE - 세션이 만료된 상태의 요청에 대해 internal server error 가 뜨던 현상 수정

### DIFF
--- a/amatta_server/src/main/java/com/amatta/amatta_server/aop/AuthorizationAop.java
+++ b/amatta_server/src/main/java/com/amatta/amatta_server/aop/AuthorizationAop.java
@@ -25,7 +25,9 @@ public class AuthorizationAop {
 
         HttpServletRequest request = ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder.getRequestAttributes())).getRequest();
         HttpSession session = request.getSession(false);
-
+        if(session == null) {
+            throw new NotAuthenticatedException();
+        }
         Users user = (Users) session.getAttribute("User");
         if(user == null) {
             throw new NotAuthenticatedException();
@@ -38,7 +40,9 @@ public class AuthorizationAop {
 
         HttpServletRequest request = ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder.getRequestAttributes())).getRequest();
         HttpSession session = request.getSession(false);
-
+        if(session == null) {
+            throw new NotAuthenticatedException();
+        }
         Users user = (Users) session.getAttribute("User");
         if(user == null) {
             throw new NotAuthenticatedException();

--- a/amatta_server/src/test/java/com/amatta/amatta_server/GifticonControllerTest.java
+++ b/amatta_server/src/test/java/com/amatta/amatta_server/GifticonControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +46,27 @@ public class GifticonControllerTest {
     @Test
     public void NoCookieRequestExpected4xxResponse() throws Exception {
         gMock.perform(post("/gifticon")).andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void InvalidSessionRequestExpected401Response() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        RegisterAndLoginSetup(session);
+        session.invalidate();
+        String requestBody = "{" +
+                "\"itemName\": \"아메리카노\", " +
+                "\"brandName\": \"스타벅스\", " +
+                "\"image\": \"adfadf\", " +
+                "\"thumbnail\": \"adfadfa\", " +
+                "\"price\": \"3000\", " +
+                "\"barcode\": \"12341234\", " +
+                "\"expiresAtInString\": \"2023/11/11\"" +
+                "}";
+        gMock.perform(post("/gifticon")
+                .session(session)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)).andExpect(status().isUnauthorized()).andDo(print());
     }
 
     @Test


### PR DESCRIPTION
1. session이 null일 때도 NotAuthenticated exception(401)을 뱉도록 수정